### PR TITLE
Fixes to DirectionalGhosts

### DIFF
--- a/pacai/agents/ghost/directional.py
+++ b/pacai/agents/ghost/directional.py
@@ -49,7 +49,7 @@ class DirectionalGhost(GhostAgent):
 
         for a in legalActions:
             if (key not in dict): 
-                dict[key] = 1 
+                dict[key] = 0
             dict[key] += float(1 - bestProb) / len(legalActions)
                 
         probability.normalize(dist)

--- a/pacai/agents/ghost/directional.py
+++ b/pacai/agents/ghost/directional.py
@@ -1,7 +1,7 @@
 from pacai.agents.ghost.base import GhostAgent
 from pacai.core.actions import Actions
-from pacai.util import probability
 from pacai.core import distance
+from pacai.util import probability
 
 class DirectionalGhost(GhostAgent):
     """
@@ -48,10 +48,10 @@ class DirectionalGhost(GhostAgent):
             dist[a] = float(bestProb) / len(bestActions)
 
         for a in legalActions:
-            try:
-                dist[a] += float(1 - bestProb) / len(legalActions)
-            except KeyError:
+            if not a in dist:
                 dist[a] = float(1 - bestProb) / len(legalActions)
-
+            else:
+                dist[a] += float(1 - bestProb) / len(legalActions)
+                
         probability.normalize(dist)
         return dist

--- a/pacai/agents/ghost/directional.py
+++ b/pacai/agents/ghost/directional.py
@@ -1,5 +1,6 @@
 from pacai.agents.ghost.base import GhostAgent
 from pacai.core.actions import Actions
+from pacai.util import probability
 from pacai.core import distance
 
 class DirectionalGhost(GhostAgent):
@@ -47,7 +48,10 @@ class DirectionalGhost(GhostAgent):
             dist[a] = float(bestProb) / len(bestActions)
 
         for a in legalActions:
-            dist[a] += float(1 - bestProb) / len(legalActions)
+            try:
+                dist[a] += float(1 - bestProb) / len(legalActions)
+            except KeyError:
+                dist[a] = float(1 - bestProb) / len(legalActions)
 
-        dist.normalize()
+        probability.normalize(dist)
         return dist

--- a/pacai/agents/ghost/directional.py
+++ b/pacai/agents/ghost/directional.py
@@ -48,10 +48,11 @@ class DirectionalGhost(GhostAgent):
             dist[a] = float(bestProb) / len(bestActions)
 
         for a in legalActions:
+            temp_dist = float(1 - bestProb) / len(legalActions)
             if not a in dist:
-                dist[a] = float(1 - bestProb) / len(legalActions)
+                dist[a] = temp_dist
             else:
-                dist[a] += float(1 - bestProb) / len(legalActions)
+                dist[a] += temp_dist
                 
         probability.normalize(dist)
         return dist

--- a/pacai/agents/ghost/directional.py
+++ b/pacai/agents/ghost/directional.py
@@ -48,11 +48,9 @@ class DirectionalGhost(GhostAgent):
             dist[a] = float(bestProb) / len(bestActions)
 
         for a in legalActions:
-            temp_dist = float(1 - bestProb) / len(legalActions)
-            if not a in dist:
-                dist[a] = temp_dist
-            else:
-                dist[a] += temp_dist
+            if (key not in dict): 
+                dict[key] = 1 
+            dict[key] += float(1 - bestProb) / len(legalActions)
                 
         probability.normalize(dist)
         return dist


### PR DESCRIPTION
Fixes two issues:
- KeyError when doing `dist[a] += float(1 - bestProb) / len(legalActions)`; the += action cannot be applied to non-existent keys.
- dist.normalize() is a dictionary, and does not have a .normalize(). Use probability.normalize() instead