### PR TITLE
Fix drawQValues crash

### DIFF
--- a/pacai/ui/gridworld/gui.py
+++ b/pacai/ui/gridworld/gui.py
@@ -154,9 +154,10 @@ def drawQValues(gridworld, qValues, currentState = None, message = 'State-Action
             valStrings = {}
 
             for action in actions:
-                v = qValues[(state, action)]
-                q[action] += v
-                valStrings[action] = '%.2f' % v
+                if (state, action) in qValues:
+                    v = qValues[(state, action)]
+                    q[action] = v
+                    valStrings[action] = '%.2f' % v
 
             if gridType == '#':
                 drawSquare(x, y, 0, 0, 0, None, None, True, False, isCurrent)


### PR DESCRIPTION
Fixes #60 

`drawQValues` was trying to increment (`+=`) a value from the empty dictionary `q`.
Also, some `state`s formed iterating over `x` and `y` might not exist (i.e. if it's a wall).

I've based the MR on `master` because this bug blocks current coursework.